### PR TITLE
Send callback finish() before calling super

### DIFF
--- a/app/src/main/java/com/example/android/customtabsbrowser/MainActivity.java
+++ b/app/src/main/java/com/example/android/customtabsbrowser/MainActivity.java
@@ -88,8 +88,8 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public void finish() {
-        super.finish();
         mCustomTabController.finish();
+        super.finish();
     }
 
     @Override


### PR DESCRIPTION
If we send the Activity's `finish()` first, we aren't able to send the callback successfully and this would cause a freeze up in the calling application.
